### PR TITLE
Use `carbon-preprocess-svelte` for faster, optimized builds

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@carbon/themes": "^11.44.2",
     "carbon-components-svelte": "^0.83.0",
+    "carbon-preprocess-svelte": "^0.11.13",
     "svelte": "^4.0.0",
     "vite": "^5.0.0",
     "@sveltejs/vite-plugin-svelte": "^3.0.0"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,5 +1,6 @@
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
+import { optimizeImports, optimizeCss } from "carbon-preprocess-svelte";
 
 //console.log(import.meta.env.VITE_BACKEND_URL);
 
@@ -8,7 +9,12 @@ const BACKEND_URL = import.meta.env?.VITE_BACKEND_URL || "http://localhost:8000"
 console.log("Backend URL is:", BACKEND_URL);
  
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [
+    svelte({
+      preprocess: [optimizeImports()]
+    }),
+    optimizeCss()
+  ],
   root: '.',
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
Svelte has first-class support for [preprocessors](https://svelte.dev/docs/svelte/svelte-compiler#Preprocessor). This means that code can be transformed before compilation.

I recommend incorporating the [Carbon preprocessor](https://github.com/carbon-design-system/carbon-preprocess-svelte) for faster development/production builds and optimized CSS generation.

`carbon-preprocess-svelte` automatically processes source code to rewrite Carbon imports to their optimized path, greatly reducing the number of initially loaded components.

- `optimizeImports`: automatically rewrites Carbon imports to the optimized path. Carbon has *a lot* of exports from its barrel file. Optimizing imports can significantly reduce cold start and build times, as it bypasses the need to access the barrel file.
- `optimizeCss`: Vite plugin that [optimizes CSS](https://github.com/carbon-design-system/carbon-preprocess-svelte/blob/main/src/plugins/create-optimized-css.ts) from `carbon-components-svelte` at build time.

## Results

Running locally on my machine, I observe ~3.36x (~70%) faster build times and ~57.9% reduced CSS output size (non-gzip).

**npm run build**

```diff
- ✓ 327 modules transformed.
- ✓ built in 1.50s

+ ✓ 46 modules transformed
+ ✓ built in 447ms
```

**Optimized CSS**

```diff
- dist/assets/index-Qzb__ZmV.css  746.74 kB │ gzip: 64.93 kB
+ dist/assets/index-Qzb__ZmV.css  314.00 kB │ gzip: 24.31 kB
```